### PR TITLE
Added https urls to the @include

### DIFF
--- a/colorize_standings_cf.user.js
+++ b/colorize_standings_cf.user.js
@@ -6,13 +6,21 @@
 // @copyright      yak_ex
 // @version        1.6
 // @include        http://www.codeforces.com/contest/*/standings*
+// @include        https://www.codeforces.com/contest/*/standings*
 // @include        http://www.codeforces.com/contest/*/room/*
+// @include        https://www.codeforces.com/contest/*/room/*
 // @include        http://codeforces.com/contest/*/standings*
+// @include        https://codeforces.com/contest/*/standings*
 // @include        http://codeforces.com/contest/*/room/*
+// @include        https://codeforces.com/contest/*/room/*
 // @include        http://www.codeforces.ru/contest/*/standings*
+// @include        https://www.codeforces.ru/contest/*/standings*
 // @include        http://www.codeforces.ru/contest/*/room/*
+// @include        https://www.codeforces.ru/contest/*/room/*
 // @include        http://codeforces.ru/contest/*/standings*
+// @include        https://codeforces.ru/contest/*/standings*
 // @include        http://codeforces.ru/contest/*/room/*
+// @include        https://codeforces.ru/contest/*/room/*
 // ==/UserScript==
 
 // v1.6  2015/05/05 Add GNU C11.


### PR DESCRIPTION
This is an update to file "_colorize_standings_cf.user.js_" .


**Problem Fixed :-** 

HTTPS versions of  Codeforces.com now work normally.
Before this addition, the user-script was not included by the user script manager on HTTPS URLs of codeforces.